### PR TITLE
feat: add cm3j-rpi-cm4-io

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -264,6 +264,37 @@ Depends: linux-libc-dev-${binary:Version}-rk2410-nocsf,
 Description: Radxa Linux libc-dev meta-package for Radxa CM3 IO
  This is the meta-package for Linux libc-dev.
 
+Package: linux-image-radxa-cm3j-rpi-cm4-io
+Architecture: all
+Section: kernel
+Priority: optional
+Provides: linux-image
+Depends: radxa-overlays-dkms,
+         linux-image-${binary:Version}-rk2410-nocsf,
+         ${misc:Depends},
+Description: Radxa Linux meta-package for Radxa CM3J RPI CM4 IO
+ This is the meta-package for Linux kernel.
+
+Package: linux-headers-radxa-cm3j-rpi-cm4-io
+Architecture: all
+Section: kernel
+Priority: optional
+Provides: linux-headers
+Depends: linux-headers-${binary:Version}-rk2410-nocsf,
+         ${misc:Depends},
+Description: Radxa Linux headers meta-package for Radxa CM3J RPI CM4 IO
+ This is the meta-package for Linux headers.
+
+Package: linux-libc-dev-radxa-cm3j-rpi-cm4-io
+Architecture: all
+Section: kernel
+Priority: optional
+Provides: linux-libc-dev
+Depends: linux-libc-dev-${binary:Version}-rk2410-nocsf,
+         ${misc:Depends},
+Description: Radxa Linux libc-dev meta-package for Radxa CM3J RPI CM4 IO
+ This is the meta-package for Linux libc-dev.
+
 Package: linux-image-rock-3a
 Architecture: all
 Section: kernel


### PR DESCRIPTION
Going to upgrade CM3J RPI CM4 IO Radxa OS to Debian 12 with 6.1.84 kernel.